### PR TITLE
🐛 Adjust maintained score

### DIFF
--- a/policies/template.yml
+++ b/policies/template.yml
@@ -66,5 +66,5 @@ policies:
       score: 10
       mode: enforced
   Maintained:
-      score: 10
+      score: 1
       mode: enforced


### PR DESCRIPTION
adjust the score for the Maintained check to pass to 1 instead of 10. Score of 10 means there are a large number of commits/activity in the past 90 days. We don't want to show this in the scanning results so long as there is *some* activity.