### PR TITLE
Fixing repo token secret typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ jobs:
           results_format: sarif
           # Read-only PAT token. To create it,
           # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
           # Publish the results for public repositories to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results. 
           # For private repositories, `publish_results` will automatically be set to `false`, regardless 


### PR DESCRIPTION
New Starter Workflow refers to SCORECARD_READ_TOKEN but README uses SCORECARD_TOKEN. Making the variable name consistent.