### PR TITLE
🐛 Fix null default branch/private fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ FROM gcr.io/openssf/scorecard@sha256:8165ad910019422f40c51cbb97ff6e7db0e2e2e11fa
 # TODO: use distroless.
 FROM debian:9.5-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq ca-certificates
+    apt-get install -y --no-install-recommends \
+    jq ca-certificates curl
 
 # Copy the scorecard binary from the official scorecard image.
 COPY --from=base /scorecard /scorecard

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,8 +30,7 @@ export SCORECARD_POLICY_FILE="/policy.yml" # Copied at docker image creation.
 export SCORECARD_RESULTS_FILE="$INPUT_RESULTS_FILE"
 export SCORECARD_RESULTS_FORMAT="$INPUT_RESULTS_FORMAT"
 export SCORECARD_PUBLISH_RESULTS="$INPUT_PUBLISH_RESULTS"
-export SCORECARD_PRIVATE_REPOSITORY="$(jq '.repository.private' $GITHUB_EVENT_PATH)"
-export SCORECARD_DEFAULT_BRANCH="refs/heads/$(jq -r '.repository.default_branch' $GITHUB_EVENT_PATH)"
+export SCORECARD_REPOSITORY="$(jq -r '.repository.full_name' $GITHUB_EVENT_PATH)"
 export SCORECARD_BIN="/scorecard"
 export ENABLED_CHECKS=
 
@@ -49,8 +48,8 @@ export ENABLED_CHECKS=
 #
 # Boolean inputs are strings https://github.com/actions/runner/issues/1483.
 # ===============================================================================
-export SCORECARD_PRIVATE_REPOSITORY="$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/ossf/scorecard | jq -r '.private')"
-export SCORECARD_DEFAULT_BRANCH="refs/heads/$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/ossf/scorecard | jq -r '.default_branch')"
+export SCORECARD_PRIVATE_REPOSITORY="$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/$SCORECARD_REPOSITORY | jq -r '.private')"
+export SCORECARD_DEFAULT_BRANCH="refs/heads/$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/$SCORECARD_REPOSITORY | jq -r '.default_branch')"
 
 # If the repository is private, never publish the results.
 if [[ "$SCORECARD_PRIVATE_REPOSITORY" == "true" ]]; then
@@ -65,6 +64,7 @@ fi
 echo "Event file: $GITHUB_EVENT_PATH"
 echo "Event name: $GITHUB_EVENT_NAME"
 echo "Ref: $GITHUB_REF"
+echo "Repository: $SCORECARD_REPOSITORY"
 echo "Private repository: $SCORECARD_PRIVATE_REPOSITORY"
 echo "Publication enabled: $SCORECARD_PUBLISH_RESULTS"
 echo "Format: $SCORECARD_RESULTS_FORMAT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,8 @@ export SCORECARD_DEFAULT_BRANCH="refs/heads/$(jq -r '.repository.default_branch'
 export SCORECARD_BIN="/scorecard"
 export ENABLED_CHECKS=
 
+export SCORECARD_MASTER_BRANCH="refs/heads/$(jq -r '.repository.master_branch' $GITHUB_EVENT_PATH)"
+
 # WARNING: boolean inputs are strings https://github.com/actions/runner/issues/1483.
 
 # If the repository is private, never publish the results.
@@ -56,6 +58,7 @@ echo "Publication enabled: $SCORECARD_PUBLISH_RESULTS"
 echo "Format: $SCORECARD_RESULTS_FORMAT"
 echo "Policy file: $SCORECARD_POLICY_FILE"
 echo "Default branch: $SCORECARD_DEFAULT_BRANCH"
+echo "Master branch: $SCORECARD_MASTER_BRANCH"
 
 # Note: this will fail if we push to a branch on the same repo, so it will show as failing
 # on forked repos.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,8 +48,10 @@ export ENABLED_CHECKS=
 #
 # Boolean inputs are strings https://github.com/actions/runner/issues/1483.
 # ===============================================================================
-export SCORECARD_PRIVATE_REPOSITORY="$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/$SCORECARD_REPOSITORY | jq -r '.private')"
-export SCORECARD_DEFAULT_BRANCH="refs/heads/$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/$SCORECARD_REPOSITORY | jq -r '.default_branch')"
+curl -s -H "Authorization: Bearer $GITHUB_AUTH_TOKEN" https://api.github.com/repos/$SCORECARD_REPOSITORY > repo_info.json
+export SCORECARD_PRIVATE_REPOSITORY="$(cat repo_info.json | jq -r '.private')"
+export SCORECARD_DEFAULT_BRANCH="refs/heads/$(cat repo_info.json | jq -r '.default_branch')"
+rm repo_info.json
 
 # If the repository is private, never publish the results.
 if [[ "$SCORECARD_PRIVATE_REPOSITORY" == "true" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,12 @@ echo "Format: $SCORECARD_RESULTS_FORMAT"
 echo "Policy file: $SCORECARD_POLICY_FILE"
 echo "Default branch: $SCORECARD_DEFAULT_BRANCH"
 echo "Master branch: $SCORECARD_MASTER_BRANCH"
+echo "Token: $GITHUB_TOKEN"
 
+if [[ -z "$GITHUB_TOKEN" ]]
+    then
+    echo "$GITHUB_TOKEN not empty!"
+fi
 # Note: this will fail if we push to a branch on the same repo, so it will show as failing
 # on forked repos.
 if [[ "$GITHUB_EVENT_NAME" != "pull_request"* ]] && [[ "$GITHUB_REF" != "$SCORECARD_DEFAULT_BRANCH" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ export ENABLED_CHECKS=
 # default_branch: null
 #
 # for trigger event `schedule`. This is a bug.
-# So instead we use the REST API instead to retrieve the data.
+# So instead we use the REST API to retrieve the data.
 #
 # Boolean inputs are strings https://github.com/actions/runner/issues/1483.
 # ===============================================================================

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ export ENABLED_CHECKS=
 # Boolean inputs are strings https://github.com/actions/runner/issues/1483.
 # ===============================================================================
 export SCORECARD_PRIVATE_REPOSITORY="$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/$SCORECARD_REPOSITORY | jq -r '.private')"
-export SCORECARD_DEFAULT_BRANCH="refs/heads/$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/$SCORECARD_REPOSITORY | jq -r '.default_branch')"
+export SCORECARD_DEFAULT_BRANCH="refs/heads/$(curl -s -H \"Authorization: Bearer $GITHUB_AUTH_TOKEN\" https://api.github.com/repos/$SCORECARD_REPOSITORY | jq -r '.default_branch')"
 
 # If the repository is private, never publish the results.
 if [[ "$SCORECARD_PRIVATE_REPOSITORY" == "true" ]]; then


### PR DESCRIPTION
The `repository.private` and `repository.default_branch` are null when the action is triggered by a `schedule` trigger.
I think this is a bug and I've created a support issue on GitHub to ask.

There is another field `master_branch` but it may be deprecated in the future so I would like to avoid it.

To fix the issue, I'm querying a REST API instead, which seems more reliable.

closes https://github.com/ossf/scorecard-action/issues/73