### PR TITLE
Remove env vars

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,5 @@ jobs:
         with:
           go-version: '1.17.x'
       - name: Run Go tests
-        run: go test -race ./...
+        # cannot run tests with race because we are mutating state (setting ENV variables)
+        run: go test ./...

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var (
 	enabledChecks                 = ""
 	scorecardPrivateRepository    = ""
 	scorecardDefaultBranch        = ""
+	scorecardPublishResults       = ""
 )
 
 type repositoryInformation struct {
@@ -61,17 +62,16 @@ const (
 	githubRef               = "GITHUB_REF"
 	githubWorkspace         = "GITHUB_WORKSPACE"
 	//nolint:gosec
-	githubAuthToken         = "GITHUB_AUTH_TOKEN"
-	inputresultsfile        = "INPUT_RESULTS_FILE"
-	inputresultsformat      = "INPUT_RESULTS_FORMAT"
-	inputpublishresults     = "INPUT_PUBLISH_RESULTS"
-	scorecardBin            = "/scorecard"
-	scorecardResultsFormat  = "SCORECARD_RESULTS_FORMAT"
-	scorecardPublishResults = "SCORECARD_PUBLISH_RESULTS"
-	scorecardPolicyFile     = "./policy.yml"
-	scorecardResultsFile    = "SCORECARD_RESULTS_FILE"
-	scorecardFork           = "SCORECARD_IS_FORK"
-	sarif                   = "sarif"
+	githubAuthToken        = "GITHUB_AUTH_TOKEN"
+	inputresultsfile       = "INPUT_RESULTS_FILE"
+	inputresultsformat     = "INPUT_RESULTS_FORMAT"
+	inputpublishresults    = "INPUT_PUBLISH_RESULTS"
+	scorecardBin           = "/scorecard"
+	scorecardResultsFormat = "SCORECARD_RESULTS_FORMAT"
+	scorecardPolicyFile    = "./policy.yml"
+	scorecardResultsFile   = "SCORECARD_RESULTS_FILE"
+	scorecardFork          = "SCORECARD_IS_FORK"
+	sarif                  = "sarif"
 )
 
 // main is the entrypoint for the action.
@@ -178,9 +178,7 @@ func initalizeENVVariables() error {
 		if result == "" {
 			return errInputPublishResultsEmpty
 		}
-		if err := os.Setenv(scorecardPublishResults, result); err != nil {
-			return fmt.Errorf("error setting %s: %w", scorecardPublishResults, err)
-		}
+		scorecardPublishResults = result
 	}
 
 	return gitHubEventPath()
@@ -303,9 +301,7 @@ func updateRepositoryInformation(privateRepo bool, defaultBranch string) error {
 func updateEnvVariables() error {
 	isPrivateRepo := scorecardPrivateRepository
 	if isPrivateRepo != "true" {
-		if err := os.Setenv(scorecardPublishResults, "false"); err != nil {
-			return fmt.Errorf("error setting %s: %w", scorecardPublishResults, err)
-		}
+		scorecardPublishResults = "false"
 	}
 	return nil
 }
@@ -317,7 +313,6 @@ func printEnvVariables(writer io.Writer) {
 	fmt.Fprintf(writer, "GITHUB_REPOSITORY=%s\n", os.Getenv(githubRepository))
 	fmt.Fprintf(writer, "SCORECARD_IS_FORK=%s\n", os.Getenv(scorecardFork))
 	fmt.Fprintf(writer, "Ref=%s\n", os.Getenv(githubRef))
-	fmt.Fprintf(writer, "SCORECARD_PUBLISH_RESULTS=%s\n", os.Getenv(scorecardPublishResults))
 	fmt.Fprintf(writer, "Format=%s\n", os.Getenv(scorecardResultsFormat))
 }
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var (
 	errEmptyGitHubAuthToken       = errors.New("repo_token variable is empty")
 	errOnlyDefaultBranchSupported = errors.New("only default branch is supported")
 	errEmptyScorecardBin          = errors.New("scorecard_bin variable is empty")
+	enabledChecks                 = ""
 )
 
 type repositoryInformation struct {
@@ -52,7 +53,6 @@ const (
 	enableSarif             = "ENABLE_SARIF"
 	enableLicense           = "ENABLE_LICENSE"
 	enableDangerousWorkflow = "ENABLE_DANGEROUS_WORKFLOW"
-	enabledChecks           = "ENABLED_CHECKS"
 	githubEventPath         = "GITHUB_EVENT_PATH"
 	githubEventName         = "GITHUB_EVENT_NAME"
 	githubRepository        = "GITHUB_REPOSITORY"
@@ -143,7 +143,6 @@ func initalizeENVVariables() error {
 	envvars[enableSarif] = "1"
 	envvars[enableLicense] = "1"
 	envvars[enableDangerousWorkflow] = "1"
-	envvars[enabledChecks] = ""
 
 	for key, val := range envvars {
 		if err := os.Setenv(key, val); err != nil {
@@ -384,7 +383,7 @@ func runScorecardSettings(githubEventName, scorecardPolicyFile, scorecardResults
 		return &result, nil
 	}
 
-	enabledChecks := ""
+	enabledChecks = ""
 	if githubEventName == "branch_protection_rule" {
 		enabledChecks = "--checks Branch-Protection"
 	}

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ const (
 	inputresultsfile           = "INPUT_RESULTS_FILE"
 	inputresultsformat         = "INPUT_RESULTS_FORMAT"
 	inputpublishresults        = "INPUT_PUBLISH_RESULTS"
-	scorecardBin               = "SCORECARD_BIN"
+	scorecardBin               = "/scorecard"
 	scorecardResultsFormat     = "SCORECARD_RESULTS_FORMAT"
 	scorecardPublishResults    = "SCORECARD_PUBLISH_RESULTS"
 	scorecardPolicyFile        = "./policy.yml"
@@ -110,7 +110,7 @@ func main() {
 	// gets the cmd run settings
 	cmd, err := runScorecardSettings(os.Getenv(githubEventName),
 		scorecardPolicyFile, os.Getenv(scorecardResultsFormat),
-		os.Getenv(scorecardBin), os.Getenv(scorecardResultsFile), os.Getenv(githubRepository))
+		scorecardBin, os.Getenv(scorecardResultsFile), os.Getenv(githubRepository))
 	if err != nil {
 		panic(err)
 	}
@@ -143,7 +143,6 @@ func initalizeENVVariables() error {
 	envvars[enableSarif] = "1"
 	envvars[enableLicense] = "1"
 	envvars[enableDangerousWorkflow] = "1"
-	envvars[scorecardBin] = "/scorecard"
 	envvars[enabledChecks] = ""
 
 	for key, val := range envvars {

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var (
 	errOnlyDefaultBranchSupported = errors.New("only default branch is supported")
 	errEmptyScorecardBin          = errors.New("scorecard_bin variable is empty")
 	enabledChecks                 = ""
+	scorecardPrivateRepository    = ""
 )
 
 type repositoryInformation struct {
@@ -59,19 +60,18 @@ const (
 	githubRef               = "GITHUB_REF"
 	githubWorkspace         = "GITHUB_WORKSPACE"
 	//nolint:gosec
-	githubAuthToken            = "GITHUB_AUTH_TOKEN"
-	inputresultsfile           = "INPUT_RESULTS_FILE"
-	inputresultsformat         = "INPUT_RESULTS_FORMAT"
-	inputpublishresults        = "INPUT_PUBLISH_RESULTS"
-	scorecardBin               = "/scorecard"
-	scorecardResultsFormat     = "SCORECARD_RESULTS_FORMAT"
-	scorecardPublishResults    = "SCORECARD_PUBLISH_RESULTS"
-	scorecardPolicyFile        = "./policy.yml"
-	scorecardResultsFile       = "SCORECARD_RESULTS_FILE"
-	scorecardFork              = "SCORECARD_IS_FORK"
-	scorecardDefaultBranch     = "SCORECARD_DEFAULT_BRANCH"
-	scorecardPrivateRepository = "SCORECARD_PRIVATE_REPOSITORY"
-	sarif                      = "sarif"
+	githubAuthToken         = "GITHUB_AUTH_TOKEN"
+	inputresultsfile        = "INPUT_RESULTS_FILE"
+	inputresultsformat      = "INPUT_RESULTS_FORMAT"
+	inputpublishresults     = "INPUT_PUBLISH_RESULTS"
+	scorecardBin            = "/scorecard"
+	scorecardResultsFormat  = "SCORECARD_RESULTS_FORMAT"
+	scorecardPublishResults = "SCORECARD_PUBLISH_RESULTS"
+	scorecardPolicyFile     = "./policy.yml"
+	scorecardResultsFile    = "SCORECARD_RESULTS_FILE"
+	scorecardFork           = "SCORECARD_IS_FORK"
+	scorecardDefaultBranch  = "SCORECARD_DEFAULT_BRANCH"
+	sarif                   = "sarif"
 )
 
 // main is the entrypoint for the action.
@@ -293,9 +293,7 @@ func updateRepositoryInformation(privateRepo bool, defaultBranch string) error {
 		return errEmptyDefaultBranch
 	}
 
-	if err := os.Setenv(scorecardPrivateRepository, strconv.FormatBool(privateRepo)); err != nil {
-		return fmt.Errorf("error setting %s: %w", scorecardPrivateRepository, err)
-	}
+	scorecardPrivateRepository = strconv.FormatBool(privateRepo)
 	if err := os.Setenv(scorecardDefaultBranch, fmt.Sprintf("refs/heads/%s", defaultBranch)); err != nil {
 		return fmt.Errorf("error setting %s: %w", scorecardDefaultBranch, err)
 	}
@@ -304,7 +302,7 @@ func updateRepositoryInformation(privateRepo bool, defaultBranch string) error {
 
 // updateEnvVariables is a function to update the ENV variables based on results format and private repository.
 func updateEnvVariables() error {
-	isPrivateRepo := os.Getenv(scorecardPrivateRepository)
+	isPrivateRepo := scorecardPrivateRepository
 	if isPrivateRepo != "true" {
 		if err := os.Setenv(scorecardPublishResults, "false"); err != nil {
 			return fmt.Errorf("error setting %s: %w", scorecardPublishResults, err)
@@ -320,7 +318,6 @@ func printEnvVariables(writer io.Writer) {
 	fmt.Fprintf(writer, "GITHUB_REPOSITORY=%s\n", os.Getenv(githubRepository))
 	fmt.Fprintf(writer, "SCORECARD_IS_FORK=%s\n", os.Getenv(scorecardFork))
 	fmt.Fprintf(writer, "Ref=%s\n", os.Getenv(githubRef))
-	fmt.Fprintf(writer, "SCORECARD_PRIVATE_REPOSITORY=%s\n", os.Getenv(scorecardPrivateRepository))
 	fmt.Fprintf(writer, "SCORECARD_PUBLISH_RESULTS=%s\n", os.Getenv(scorecardPublishResults))
 	fmt.Fprintf(writer, "Format=%s\n", os.Getenv(scorecardResultsFormat))
 	fmt.Fprintf(writer, "Default branch=%s\n", os.Getenv(scorecardDefaultBranch))

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var (
 	scorecardPrivateRepository    = ""
 	scorecardDefaultBranch        = ""
 	scorecardPublishResults       = ""
+	scorecardResultsFormat        = ""
 )
 
 type repositoryInformation struct {
@@ -62,16 +63,15 @@ const (
 	githubRef               = "GITHUB_REF"
 	githubWorkspace         = "GITHUB_WORKSPACE"
 	//nolint:gosec
-	githubAuthToken        = "GITHUB_AUTH_TOKEN"
-	inputresultsfile       = "INPUT_RESULTS_FILE"
-	inputresultsformat     = "INPUT_RESULTS_FORMAT"
-	inputpublishresults    = "INPUT_PUBLISH_RESULTS"
-	scorecardBin           = "/scorecard"
-	scorecardResultsFormat = "SCORECARD_RESULTS_FORMAT"
-	scorecardPolicyFile    = "./policy.yml"
-	scorecardResultsFile   = "SCORECARD_RESULTS_FILE"
-	scorecardFork          = "SCORECARD_IS_FORK"
-	sarif                  = "sarif"
+	githubAuthToken      = "GITHUB_AUTH_TOKEN"
+	inputresultsfile     = "INPUT_RESULTS_FILE"
+	inputresultsformat   = "INPUT_RESULTS_FORMAT"
+	inputpublishresults  = "INPUT_PUBLISH_RESULTS"
+	scorecardBin         = "/scorecard"
+	scorecardPolicyFile  = "./policy.yml"
+	scorecardResultsFile = "SCORECARD_RESULTS_FILE"
+	scorecardFork        = "SCORECARD_IS_FORK"
+	sarif                = "sarif"
 )
 
 // main is the entrypoint for the action.
@@ -109,7 +109,7 @@ func main() {
 
 	// gets the cmd run settings
 	cmd, err := runScorecardSettings(os.Getenv(githubEventName),
-		scorecardPolicyFile, os.Getenv(scorecardResultsFormat),
+		scorecardPolicyFile, scorecardResultsFormat,
 		scorecardBin, os.Getenv(scorecardResultsFile), os.Getenv(githubRepository))
 	if err != nil {
 		panic(err)
@@ -167,9 +167,7 @@ func initalizeENVVariables() error {
 		if result == "" {
 			return errInputResultFormatEmtpy
 		}
-		if err := os.Setenv(scorecardResultsFormat, result); err != nil {
-			return fmt.Errorf("error setting %s: %w", scorecardResultsFormat, err)
-		}
+		scorecardResultsFormat = result
 	}
 
 	if result, exists := os.LookupEnv(inputpublishresults); !exists {
@@ -313,7 +311,6 @@ func printEnvVariables(writer io.Writer) {
 	fmt.Fprintf(writer, "GITHUB_REPOSITORY=%s\n", os.Getenv(githubRepository))
 	fmt.Fprintf(writer, "SCORECARD_IS_FORK=%s\n", os.Getenv(scorecardFork))
 	fmt.Fprintf(writer, "Ref=%s\n", os.Getenv(githubRef))
-	fmt.Fprintf(writer, "Format=%s\n", os.Getenv(scorecardResultsFormat))
 }
 
 // validate is a function to validate the scorecard configuration based on the environment variables.

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ const (
 	scorecardBin               = "SCORECARD_BIN"
 	scorecardResultsFormat     = "SCORECARD_RESULTS_FORMAT"
 	scorecardPublishResults    = "SCORECARD_PUBLISH_RESULTS"
-	scorecardPolicyFile        = "SCORECARD_POLICY_FILE"
+	scorecardPolicyFile        = "./policy.yml"
 	scorecardResultsFile       = "SCORECARD_RESULTS_FILE"
 	scorecardFork              = "SCORECARD_IS_FORK"
 	scorecardDefaultBranch     = "SCORECARD_DEFAULT_BRANCH"
@@ -109,7 +109,7 @@ func main() {
 
 	// gets the cmd run settings
 	cmd, err := runScorecardSettings(os.Getenv(githubEventName),
-		os.Getenv(scorecardPolicyFile), os.Getenv(scorecardResultsFormat),
+		scorecardPolicyFile, os.Getenv(scorecardResultsFormat),
 		os.Getenv(scorecardBin), os.Getenv(scorecardResultsFile), os.Getenv(githubRepository))
 	if err != nil {
 		panic(err)
@@ -143,7 +143,6 @@ func initalizeENVVariables() error {
 	envvars[enableSarif] = "1"
 	envvars[enableLicense] = "1"
 	envvars[enableDangerousWorkflow] = "1"
-	envvars[scorecardPolicyFile] = "./policy.yml"
 	envvars[scorecardBin] = "/scorecard"
 	envvars[enabledChecks] = ""
 
@@ -307,12 +306,6 @@ func updateRepositoryInformation(privateRepo bool, defaultBranch string) error {
 
 // updateEnvVariables is a function to update the ENV variables based on results format and private repository.
 func updateEnvVariables() error {
-	resultsFileFormat := os.Getenv(scorecardResultsFormat)
-	if resultsFileFormat != sarif {
-		if err := os.Unsetenv(scorecardPolicyFile); err != nil {
-			return fmt.Errorf("error unsetting %s: %w", scorecardPolicyFile, err)
-		}
-	}
 	isPrivateRepo := os.Getenv(scorecardPrivateRepository)
 	if isPrivateRepo != "true" {
 		if err := os.Setenv(scorecardPublishResults, "false"); err != nil {
@@ -332,7 +325,6 @@ func printEnvVariables(writer io.Writer) {
 	fmt.Fprintf(writer, "SCORECARD_PRIVATE_REPOSITORY=%s\n", os.Getenv(scorecardPrivateRepository))
 	fmt.Fprintf(writer, "SCORECARD_PUBLISH_RESULTS=%s\n", os.Getenv(scorecardPublishResults))
 	fmt.Fprintf(writer, "Format=%s\n", os.Getenv(scorecardResultsFormat))
-	fmt.Fprintf(writer, "Policy file=%s\n", os.Getenv(scorecardPolicyFile))
 	fmt.Fprintf(writer, "Default branch=%s\n", os.Getenv(scorecardDefaultBranch))
 }
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ var (
 	errEmptyScorecardBin          = errors.New("scorecard_bin variable is empty")
 	enabledChecks                 = ""
 	scorecardPrivateRepository    = ""
+	scorecardDefaultBranch        = ""
 )
 
 type repositoryInformation struct {
@@ -70,7 +71,6 @@ const (
 	scorecardPolicyFile     = "./policy.yml"
 	scorecardResultsFile    = "SCORECARD_RESULTS_FILE"
 	scorecardFork           = "SCORECARD_IS_FORK"
-	scorecardDefaultBranch  = "SCORECARD_DEFAULT_BRANCH"
 	sarif                   = "sarif"
 )
 
@@ -294,9 +294,8 @@ func updateRepositoryInformation(privateRepo bool, defaultBranch string) error {
 	}
 
 	scorecardPrivateRepository = strconv.FormatBool(privateRepo)
-	if err := os.Setenv(scorecardDefaultBranch, fmt.Sprintf("refs/heads/%s", defaultBranch)); err != nil {
-		return fmt.Errorf("error setting %s: %w", scorecardDefaultBranch, err)
-	}
+	scorecardDefaultBranch = fmt.Sprintf("refs/heads/%s", defaultBranch)
+
 	return nil
 }
 
@@ -320,7 +319,6 @@ func printEnvVariables(writer io.Writer) {
 	fmt.Fprintf(writer, "Ref=%s\n", os.Getenv(githubRef))
 	fmt.Fprintf(writer, "SCORECARD_PUBLISH_RESULTS=%s\n", os.Getenv(scorecardPublishResults))
 	fmt.Fprintf(writer, "Format=%s\n", os.Getenv(scorecardResultsFormat))
-	fmt.Fprintf(writer, "Default branch=%s\n", os.Getenv(scorecardDefaultBranch))
 }
 
 // validate is a function to validate the scorecard configuration based on the environment variables.
@@ -336,9 +334,9 @@ func validate(writer io.Writer) error {
 		return errEmptyGitHubAuthToken
 	}
 	if strings.Contains(os.Getenv(githubEventName), "pull_request") &&
-		os.Getenv(githubRef) == os.Getenv(scorecardDefaultBranch) {
+		os.Getenv(githubRef) == scorecardDefaultBranch {
 		fmt.Fprintf(writer, "%s not supported with %s event.\n", os.Getenv(githubRef), os.Getenv(githubEventName))
-		fmt.Fprintf(writer, "Only the default branch %s is supported.\n", os.Getenv(scorecardDefaultBranch))
+		fmt.Fprintf(writer, "Only the default branch %s is supported.\n", scorecardDefaultBranch)
 		return errOnlyDefaultBranchSupported
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ var (
 	scorecardDefaultBranch        = ""
 	scorecardPublishResults       = ""
 	scorecardResultsFormat        = ""
+	scorecardResultsFile          = ""
 )
 
 type repositoryInformation struct {
@@ -63,15 +64,14 @@ const (
 	githubRef               = "GITHUB_REF"
 	githubWorkspace         = "GITHUB_WORKSPACE"
 	//nolint:gosec
-	githubAuthToken      = "GITHUB_AUTH_TOKEN"
-	inputresultsfile     = "INPUT_RESULTS_FILE"
-	inputresultsformat   = "INPUT_RESULTS_FORMAT"
-	inputpublishresults  = "INPUT_PUBLISH_RESULTS"
-	scorecardBin         = "/scorecard"
-	scorecardPolicyFile  = "./policy.yml"
-	scorecardResultsFile = "SCORECARD_RESULTS_FILE"
-	scorecardFork        = "SCORECARD_IS_FORK"
-	sarif                = "sarif"
+	githubAuthToken     = "GITHUB_AUTH_TOKEN"
+	inputresultsfile    = "INPUT_RESULTS_FILE"
+	inputresultsformat  = "INPUT_RESULTS_FORMAT"
+	inputpublishresults = "INPUT_PUBLISH_RESULTS"
+	scorecardBin        = "/scorecard"
+	scorecardPolicyFile = "./policy.yml"
+	scorecardFork       = "SCORECARD_IS_FORK"
+	sarif               = "sarif"
 )
 
 // main is the entrypoint for the action.
@@ -110,7 +110,7 @@ func main() {
 	// gets the cmd run settings
 	cmd, err := runScorecardSettings(os.Getenv(githubEventName),
 		scorecardPolicyFile, scorecardResultsFormat,
-		scorecardBin, os.Getenv(scorecardResultsFile), os.Getenv(githubRepository))
+		scorecardBin, scorecardResultsFile, os.Getenv(githubRepository))
 	if err != nil {
 		panic(err)
 	}
@@ -119,7 +119,7 @@ func main() {
 		panic(err)
 	}
 
-	results, err := ioutil.ReadFile(os.Getenv(scorecardResultsFile))
+	results, err := ioutil.ReadFile(scorecardResultsFile)
 	if err != nil {
 		panic(err)
 	}
@@ -156,9 +156,7 @@ func initalizeENVVariables() error {
 		if result == "" {
 			return errInputResultFileEmpty
 		}
-		if err := os.Setenv(scorecardResultsFile, result); err != nil {
-			return fmt.Errorf("error setting %s: %w", scorecardResultsFile, err)
-		}
+		scorecardResultsFile = result
 	}
 
 	if result, exists := os.LookupEnv(inputresultsformat); !exists {

--- a/main_test.go
+++ b/main_test.go
@@ -243,7 +243,7 @@ func Test_updateEnvVariables(t *testing.T) {
 				t.Errorf("updateEnvVariables() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && tt.isPrivateRepo {
-				if os.Getenv(scorecardPublishResults) != "false" {
+				if scorecardPublishResults != "false" {
 					t.Errorf("scorecardPublishResults env var should be false")
 				}
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -301,7 +301,7 @@ func Test_updateRepoistoryInformation(t *testing.T) {
 				t.Errorf("updateRepoistoryInformation() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.args.privateRepo {
-				if os.Getenv(scorecardPrivateRepository) != strconv.FormatBool(tt.args.privateRepo) {
+				if scorecardPrivateRepository != strconv.FormatBool(tt.args.privateRepo) {
 					t.Errorf("scorecardPublishResults env var should be false")
 				}
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -306,7 +306,7 @@ func Test_updateRepoistoryInformation(t *testing.T) {
 				}
 			}
 			if tt.args.defaultBranch != "" {
-				if os.Getenv(scorecardDefaultBranch) != fmt.Sprintf("refs/heads/%s", tt.args.defaultBranch) {
+				if scorecardDefaultBranch != fmt.Sprintf("refs/heads/%s", tt.args.defaultBranch) {
 					t.Errorf("scorecardDefaultBranch env var should be %s", tt.args.defaultBranch)
 				}
 			}
@@ -464,10 +464,7 @@ func Test_validate(t *testing.T) {
 				defer os.Unsetenv(githubRef)
 			}
 			if tt.scorecardDefaultBranch != "" {
-				if err := os.Setenv(scorecardDefaultBranch, tt.scorecardDefaultBranch); err != nil {
-					t.Errorf("failed to set env var %s", scorecardDefaultBranch)
-				}
-				defer os.Unsetenv(scorecardDefaultBranch)
+				scorecardDefaultBranch = tt.scorecardDefaultBranch
 			}
 			if tt.authToken != "" {
 				if err := os.Setenv(githubAuthToken, tt.authToken); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -204,7 +204,6 @@ func Test_initalizeENVVariables(t *testing.T) {
 			envvars[enableSarif] = "1"
 			envvars[enableLicense] = "1"
 			envvars[enableDangerousWorkflow] = "1"
-			envvars[scorecardBin] = "/scorecard"
 			envvars[enabledChecks] = ""
 
 			for k, v := range envvars {

--- a/main_test.go
+++ b/main_test.go
@@ -204,7 +204,6 @@ func Test_initalizeENVVariables(t *testing.T) {
 			envvars[enableSarif] = "1"
 			envvars[enableLicense] = "1"
 			envvars[enableDangerousWorkflow] = "1"
-			envvars[scorecardPolicyFile] = "./policy.yml"
 			envvars[scorecardBin] = "/scorecard"
 			envvars[enabledChecks] = ""
 

--- a/main_test.go
+++ b/main_test.go
@@ -204,7 +204,6 @@ func Test_initalizeENVVariables(t *testing.T) {
 			envvars[enableSarif] = "1"
 			envvars[enableLicense] = "1"
 			envvars[enableDangerousWorkflow] = "1"
-			envvars[enabledChecks] = ""
 
 			for k, v := range envvars {
 				if os.Getenv(k) != v {


### PR DESCRIPTION
issue #107 
Moving the following variables in main.go from env vars to native Go vars.
- [x] 1. SCORECARD_POLICY_FILE 
- [x] 2. SCORECARD_RESULTS_FILE
- [x] 3. SCORECARD_RESULTS_FORMAT
- [x] 4. SCORECARD_PUBLISH_RESULTS
- [x] 5. SCORECARD_BIN
- [x] 6. ENABLED_CHECKS
- [x] 7. SCORECARD_PRIVATE_REPOSITORY
- [x] 8. SCORECARD_DEFAULT_BRANCH
- [ ] 9. SCORECARD_IS_FORK (is currently a function?)

