### PR TITLE
golangci-lint: Fix GCI warnings

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 jobs:
-   lint:
+  lint:
     name: Run golangci lint
     runs-on: ${{ matrix.os }}
     strategy:
@@ -37,5 +37,4 @@ jobs:
           go-version: '1.17.x'
       - uses: golangci/golangci-lint-action@b517f99ae23d86ecc4c0dec08dcf48d2336abc29
         with:
-         version: v1.44.0
-         only-new-issues: true
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,7 +78,10 @@ linters-settings:
       - FIXME
       - HACK
   gci:
-    local-prefixes: github.com/ossf/scorecard-action
+    sections:
+      - standard
+      - default
+      - prefix(github.com/ossf)
   gocritic:
     enabled-checks:
       # Diagnostic


### PR DESCRIPTION
Fixes needed for https://github.com/ossf/scorecard-action/pull/122.

From https://golangci-lint.run/usage/linters/#gci:

```yaml
linters-settings:
  gci:
    # DEPRECATED: use `sections` and `prefix(github.com/org/project)` instead.
    local-prefixes: github.com/org/project
    # Checks that no inline Comments are present.
    # Default: false
    no-inline-comments: true
    # Checks that no prefix Comments(comment lines above an import) are present.
    # Default: false
    no-prefix-comments: true
    # Section configuration to compare against.
    # Section names are case-insensitive and may contain parameters in ().
    # Default: ["standard", "default"]
    sections:
      - standard # Captures all standard packages if they do not match another section.
      - default # Contains all imports that could not be matched to another section type.
      - comment(your text here) # Prints the specified indented comment.
      - newLine # Prints an empty line
      - prefix(github.com/org/project) # Groups all imports with the specified Prefix.
    # Separators that should be present between sections.
    # Default: ["newLine"]
    section-separators:
      - newLine
```

`local-prefixes` is deprecated, so we use `sections` here instead.

Because of a few things:
- dependabot automatically updates golangci-lint-action versions
- the `gci` linter warning is something that would've been caught with a newer version of `golangci-lint`

I've also dropped the `version` configuration, so it will default to using the latest version of `golangci-lint` when running CI.

Signed-off-by: Stephen Augustus <foo@auggie.dev>