### PR TITLE
🐛 Avoid error on `json` and `default` inputs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,9 @@ echo "Fork repository: $SCORECARD_IS_FORK"
 echo "Private repository: $SCORECARD_PRIVATE_REPOSITORY"
 echo "Publication enabled: $SCORECARD_PUBLISH_RESULTS"
 echo "Format: $SCORECARD_RESULTS_FORMAT"
-echo "Policy file: $SCORECARD_POLICY_FILE"
+if ! [ -z ${SCORECARD_POLICY_FILE+x} ]; then
+  echo "Policy file: $SCORECARD_POLICY_FILE"
+fi
 echo "Default branch: $SCORECARD_DEFAULT_BRANCH"
 echo "$(<repo_info.json)"
 rm repo_info.json
@@ -113,8 +115,7 @@ cd "$GITHUB_WORKSPACE"
 if [[ "$GITHUB_EVENT_NAME" == "pull_request"* ]]
 then
     # For pull request events, we run on a local folder.
-    if [[ -z "$SCORECARD_POLICY_FILE" ]]
-    then
+    if [ -z ${SCORECARD_POLICY_FILE+x} ]; then
         $SCORECARD_BIN --local . --format "$SCORECARD_RESULTS_FORMAT" --show-details > "$SCORECARD_RESULTS_FILE"
     else
         $SCORECARD_BIN --local . --format "$SCORECARD_RESULTS_FORMAT" --show-details --policy "$SCORECARD_POLICY_FILE" > "$SCORECARD_RESULTS_FILE"
@@ -123,17 +124,17 @@ else
     # For other events, we run on the repo.
 
     # For the branch protection trigger, we only run the Branch-Protection check.
-    if [[ "$GITHUB_EVENT_NAME" == "branch_protection_rule" ]]
-    then
+    if [[ "$GITHUB_EVENT_NAME" == "branch_protection_rule" ]]; then
         export ENABLED_CHECKS="--checks Branch-Protection"
     fi
-    
-    if [[ -z "$SCORECARD_POLICY_FILE" ]]
-    then
+
+    if [ -z ${SCORECARD_POLICY_FILE+x} ]; then
         $SCORECARD_BIN --repo="$GITHUB_REPOSITORY" --format "$SCORECARD_RESULTS_FORMAT" $ENABLED_CHECKS --show-details > "$SCORECARD_RESULTS_FILE"
     else
         $SCORECARD_BIN --repo="$GITHUB_REPOSITORY" --format "$SCORECARD_RESULTS_FORMAT" $ENABLED_CHECKS --show-details --policy "$SCORECARD_POLICY_FILE" > "$SCORECARD_RESULTS_FILE"
     fi
 fi
 
-jq '.' "$SCORECARD_RESULTS_FILE"
+if [[ "$SCORECARD_RESULTS_FORMAT" != "default" ]]; then
+  jq '.' "$SCORECARD_RESULTS_FILE"
+fi


### PR DESCRIPTION
Referring to an unset var causes `unbound variable` error. Check if the var is set before we refer to it. Fixes #386.