### PR TITLE
Included CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following users/teams will be requested for
+# review when someone opens a pull request.
+# TODO(owners): For ease of management, this should eventually shift to a
+#               defined GitHub team instead of individual usernames
+* @azeemshaikh38 @justaugustus @laurentsimon @naveensrinivasan
+
+# Docs
+# TODO(owners): For ease of management, this should eventually shift to a
+#               defined GitHub team instead of individual usernames
+*.md @olivekl
+/docs/ @olivekl


### PR DESCRIPTION
- This is similar to codeowners in scorecard
https://github.com/ossf/scorecard/blob/8f96d6ba25175cddeda57c5b7c1811a073a0765d/.github/CODEOWNERS#L9

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
