### PR TITLE
🐛 Fix intermittent failures in CI-Tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
           go-version: '1.18'
       - name: Run Go tests
         # cannot run tests with race because we are mutating state (setting ENV variables)
-        run: go test -covermode=atomic  -coverprofile=unit-coverage.out ./...
+        run: GITHUB_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} go test -covermode=atomic  -coverprofile=unit-coverage.out ./...
       - name: Upload codecoverage
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
         with:

--- a/signing/signing_test.go
+++ b/signing/signing_test.go
@@ -79,7 +79,7 @@ func Test_ProcessSignature(t *testing.T) {
 	jsonPayload, err := os.ReadFile("testdata/results.json")
 	repoName := "ossf-tests/scorecard-action"
 	repoRef := "refs/heads/main"
-	accessToken := ""
+	accessToken := os.Getenv("GITHUB_AUTH_TOKEN")
 
 	if err != nil {
 		t.Errorf("Error reading testdata:, %v", err)


### PR DESCRIPTION
CI-Tests are failing because of authentication issues. This PR should hopefully fix that.