### PR TITLE
🐛 Add request application/json request header

### DIFF
--- a/signing/signing.go
+++ b/signing/signing.go
@@ -115,6 +115,7 @@ func ProcessSignature(jsonPayload []byte, repoName, repoRef, accessToken string)
 	if err != nil {
 		return fmt.Errorf("creating HTTP request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
Explicitly adds `application/json` request header. API calls with stricter verification fail without this header.