### PR TITLE
Create a new release v2.0.0-alpha.1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.0.0-beta.1"
-
-
+  image: "docker://gcr.io/openssf/scorecard-action:v2.0.0-alpha.1"

--- a/signing/signing.go
+++ b/signing/signing.go
@@ -33,6 +33,8 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 )
 
+const scorecardAPI = "https://api.securityscorecards.dev"
+
 // SignScorecardResult signs the results file and uploads the attestation to the Rekor transparency log.
 func SignScorecardResult(scorecardResultsFile string) error {
 	if err := os.Setenv("COSIGN_EXPERIMENTAL", "true"); err != nil {
@@ -106,7 +108,11 @@ func ProcessSignature(jsonPayload []byte, repoName, repoRef, accessToken string)
 
 	// Call scorecard-webapp-api to process and upload signature.
 	// Setup HTTP request and context.
-	rawURL := fmt.Sprintf("https://api.securityscorecards.dev/projects/github.com/%s", repoName)
+	apiURL := scorecardAPI
+	if scorecardURL, exists := os.LookupEnv("SCORECARD_API_URL"); exists {
+		apiURL = scorecardURL
+	}
+	rawURL := fmt.Sprintf("%s/projects/github.com/%s", apiURL, repoName)
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("parsing Scorecard API endpoint: %w", err)


### PR DESCRIPTION
The fixes made in #791 need to be released to users. So creating a alpha release.

This PR also allows for the API url to be overridden. Used in e2e tests.

Part of #801.