### PR TITLE
🐛 Downgrade to scorecard:v4.5.0 to fix breakage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # NOTE: Keep this in sync with go.mod for ossf/scorecard.
-LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v4.6.0 -X sigs.k8s.io/release-utils/version.gitCommit=2cbf5afd5460b51fd40939f8c44b32543b1a0bcb -w -extldflags \"-static\"
+LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v4.5.0 -X sigs.k8s.io/release-utils/version.gitCommit=69eb1ccf1d0cf8c5b291044479f18672bf250325 -w -extldflags \"-static\"
 
 build: ## Runs go build on repo
 	# Run go build and generate scorecard executable

--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.0.0"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.0.1"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v46 v46.0.0
-	github.com/ossf/scorecard/v4 v4.6.0
+	github.com/ossf/scorecard/v4 v4.5.0
 	github.com/sigstore/cosign v1.11.1
 	github.com/spf13/cobra v1.5.0
 	golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48

--- a/go.sum
+++ b/go.sum
@@ -1313,8 +1313,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/ossf/scorecard/v4 v4.6.0 h1:rlbReCdx4CS8wbpv4kBYOojpp2969gXJ/vFx6Mf0XdQ=
-github.com/ossf/scorecard/v4 v4.6.0/go.mod h1:xnOs/f1gk03rYt4/RUEeSmF5A4+EZKQwIzxh+weDsRI=
+github.com/ossf/scorecard/v4 v4.5.0 h1:0wiW7Foh5J/JM3nNRtMnIxR26JY3WfUHpFHGhGoWrz4=
+github.com/ossf/scorecard/v4 v4.5.0/go.mod h1:VbPQTiarPj6TgbiPBg6H8jDpaDjhg1uzooe0+7dNkXA=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=


### PR DESCRIPTION
Signed-off-by: Azeem Shaikh <azeemshaikh38@gmail.com>

With the upgrade to scorecard:v4.6.0, Branch-Protection is erroring out. This downgrades to v4.5.0 until we investigate the issue. Workaround for #856 