### PR TITLE
Create v2.0.4 patch

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.0.3"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.0.4"


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

Proper fix for #856 that reverts scorecard downgrade. Now uses scorecard v4.7.0

