### PR TITLE
🐛 Fix to not upload the result in the security dashboard if it is a pull request

### DIFF
--- a/starter-workflows/code-scanning/scorecards.yml
+++ b/starter-workflows/code-scanning/scorecards.yml
@@ -66,6 +66,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
+        if: ${{ github.event_name != 'pull_request' }}
         uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Closes #977 

Regarding the issue #977, I couldn't think of a better way of doing this instead of adding the if clause to the default yml file, let me know if I missed some better idea to fix. 