### PR TITLE
🌱 Use root user in distroless to support GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,5 @@ RUN CGO_ENABLED=0 make build
 # Need root for GitHub Actions support
 FROM gcr.io/distroless/base@sha256:122585ba4c098993df9f8dc7285433e8a19974de32528ee3a4b07308808c84ce
 COPY --from=build /src/scorecard-action /
+COPY policies/template.yml /policy.yml
 ENTRYPOINT [ "/scorecard-action" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build
 
-FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
+# Need root for GitHub Actions support
+FROM gcr.io/distroless/base@sha256:122585ba4c098993df9f8dc7285433e8a19974de32528ee3a4b07308808c84ce
 COPY --from=build /src/scorecard-action /
 ENTRYPOINT [ "/scorecard-action" ]


### PR DESCRIPTION
root is needed to support GHA
https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user

The policy file is also needed or the [action will fail](https://github.com/spencerschrock/scorecard-action-branch-protection-e2e/actions/runs/3322399756/jobs/5491366014#step:4:200). In the future we should double check this is the policy we expect to be used.
```
2022/10/25 15:52:42 error during command execution: readPolicy: internal error: os.ReadFile: open /policy.yml: no such file or directory
```

This Dockerfile was tested locally and with GHA
https://github.com/spencerschrock/scorecard-action-branch-protection-e2e/actions/runs/3322399756

Fixes #989 
Fixes #990 
Fixes #991 
Fixes #992 
Fixes #993