### PR TITLE
Make the badge text easier to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,7 @@ Starting with scorecard-action:v2, users can use a REST API to query their lates
 Starting with scorecard-action:v2, users can add a Scorecard Badge to their README to display the latest status of their Scorecard results. This requires setting [`publish_results: true`](https://github.com/ossf/scorecard/blob/d13ba3f3355b958d5d62edc47282a2e7ed9fa7c1/.github/workflows/scorecard-analysis.yml#L39) for the action and enabling [`id-token: write`](https://github.com/ossf/scorecard/blob/d13ba3f3355b958d5d62edc47282a2e7ed9fa7c1/.github/workflows/scorecard-analysis.yml#L22) permission for the job (needed to access GitHub OIDC token). The badge is updated on every run of scorecard-action and points to the latest result. To add a badge to your README, copy and paste the below lines:
 
 ```
-[![OpenSSF Scorecard]
-(https://api.securityscorecards.dev/projects/github.com/{org}/{repo}/badge)]
-(https://api.securityscorecards.dev/projects/github.com/{org}/{repo})
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{org}/{repo}/badge)](https://api.securityscorecards.dev/projects/github.com/{org}/{repo})
 ```
 
 Once this badge is added, clicking on the badge will take users to the latest run result of Scorecard.

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ Starting with scorecard-action:v2, users can use a REST API to query their lates
 
 ### Scorecard Badge
 
-Starting with scorecard-action:v2, users can add a Scorecard Badge to their README to display the latest status of their Scorecard results. This requires setting [`publish_results: true`](https://github.com/ossf/scorecard/blob/d13ba3f3355b958d5d62edc47282a2e7ed9fa7c1/.github/workflows/scorecard-analysis.yml#L39) for the action and enabling [`id-token: write`](https://github.com/ossf/scorecard/blob/d13ba3f3355b958d5d62edc47282a2e7ed9fa7c1/.github/workflows/scorecard-analysis.yml#L22) permission for the job (needed to access GitHub OIDC token). The badge is updated on every run of scorecard-action and points to the latest result. To add a badge to your README, copy and paste the below lines:
+Starting with scorecard-action:v2, users can add a Scorecard Badge to their README to display the latest status of their Scorecard results. This requires setting [`publish_results: true`](https://github.com/ossf/scorecard/blob/d13ba3f3355b958d5d62edc47282a2e7ed9fa7c1/.github/workflows/scorecard-analysis.yml#L39) for the action and enabling [`id-token: write`](https://github.com/ossf/scorecard/blob/d13ba3f3355b958d5d62edc47282a2e7ed9fa7c1/.github/workflows/scorecard-analysis.yml#L22) permission for the job (needed to access GitHub OIDC token). The badge is updated on every run of scorecard-action and points to the latest result. To add a badge to your README, copy and paste the below line, and replace the {owner} and {repo} parts.
 
 ```
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{org}/{repo}/badge)](https://api.securityscorecards.dev/projects/github.com/{org}/{repo})
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}/badge)](https://api.securityscorecards.dev/projects/github.com/{owner}/{repo})
 ```
 
 Once this badge is added, clicking on the badge will take users to the latest run result of Scorecard.


### PR DESCRIPTION
I have copied that line a couple of times and forgot to remove the spaces in it more than once 🙈 . 
Making it a one line will prevent more users from going through this cycle (there where two spaces, so often two extra commits before it worked!).

Also updated the `org` variable --> `owner`, since you can either have an organization repo or a user repo, so it's common to refer to `owner`.