### PR TITLE
🌱 Bump scorecard dependency to v4.10.2 to remove a CODEOWNERS printf statement.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # NOTE: Keep this in sync with go.mod for ossf/scorecard.
-LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v4.8.0 -X sigs.k8s.io/release-utils/version.gitCommit=c40859202d739b31fd060ac5b30d17326cd74275 -w -extldflags \"-static\"
+LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v4.10.2 -X sigs.k8s.io/release-utils/version.gitCommit=376f465c111c39c6a5ad7408e8896cd790cb5219 -w -extldflags \"-static\"
 
 build: ## Runs go build on repo
 	# Run go build and generate scorecard executable

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v46 v46.0.0
-	github.com/ossf/scorecard/v4 v4.10.1
+	github.com/ossf/scorecard/v4 v4.10.2
 	github.com/sigstore/cosign v1.13.1
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1611,8 +1611,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/ossf/scorecard/v4 v4.10.1 h1:i+4EU/21ejSx9XVxQPliXKIRw4NKyGjLLr80WEW/MSw=
-github.com/ossf/scorecard/v4 v4.10.1/go.mod h1:6HwqcVjQoDRAUY0E5U6Zd41ZYmciL+zmJTmcXj081Iw=
+github.com/ossf/scorecard/v4 v4.10.2 h1:EacFulXMTLymvDxQCm/fRgdfU95i+j+Hjp6cXdKZ08I=
+github.com/ossf/scorecard/v4 v4.10.2/go.mod h1:6HwqcVjQoDRAUY0E5U6Zd41ZYmciL+zmJTmcXj081Iw=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

Bug report at https://github.com/ossf/scorecard/pull/2557 for details.