### PR TITLE
🌱 Bump docker tag for new release.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.1.1"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.1.2"


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

I've manually tested the action, as the steps in [RELEASE.md](https://github.com/ossf/scorecard-action/blob/7da02bf0d58396bc404a7e5aef3e9b0c24dcb9bc/RELEASE.md#validate-the-action) don't actually test any new changes since the docker image is pinned to a version.

I've tested with this command and confirmed the original bug (https://github.com/ossf/scorecard/pull/2557) is fixed.
```
docker run -e INPUT_REPO_TOKEN="$GITHUB_AUTH_TOKEN" \
    -e INPUT_POLICY_FILE="/policy.yml" \
    -e INPUT_RESULTS_FORMAT="sarif" \
    -e INPUT_RESULTS_FILE="results.sarif" \
    -e INPUT_PUBLISH_RESULTS="false" \
    -e GITHUB_WORKSPACE="/github/workflow" \
    -e GITHUB_REF="refs/heads/main" \
    -e GITHUB_EVENT_NAME="branch_protection_rule" \
    -e GITHUB_EVENT_PATH="/testdata/test.json" \
    -e GITHUB_REPOSITORY="nginxinc/nginx-kubernetes-gateway" \
    -e GITHUB_API_URL="https://api.github.com/" \
    -v $PWD:/github/workflow \
    gcr.io/openssf/scorecard-action:latest
 ```