### PR TITLE
🌱 Bump docker tag for release.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.1.2"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.1.3"


### PR DESCRIPTION
Only non dependabot change is use of scorecard v4.10.5 (#1111), which has been running in the nightly e2e tests for 5 days without issue.
