### PR TITLE
:bug: Skip cosign confirmation prompt when publishing scorecard results.

### DIFF
--- a/signing/signing.go
+++ b/signing/signing.go
@@ -72,10 +72,11 @@ func (s *Signing) SignScorecardResult(scorecardResultsFile string) error {
 	// Prepare settings for SignBlobCmd.
 	rootOpts := &sigOpts.RootOptions{Timeout: sigOpts.DefaultTimeout} // Just the timeout.
 	keyOpts := sigOpts.KeyOpts{
-		FulcioURL:    sigOpts.DefaultFulcioURL,     // Signing certificate provider.
-		RekorURL:     sigOpts.DefaultRekorURL,      // Transparency log.
-		OIDCIssuer:   sigOpts.DefaultOIDCIssuerURL, // OIDC provider to get ID token to auth for Fulcio.
-		OIDCClientID: "sigstore",
+		FulcioURL:        sigOpts.DefaultFulcioURL,     // Signing certificate provider.
+		RekorURL:         sigOpts.DefaultRekorURL,      // Transparency log.
+		OIDCIssuer:       sigOpts.DefaultOIDCIssuerURL, // OIDC provider to get ID token to auth for Fulcio.
+		OIDCClientID:     "sigstore",
+		SkipConfirmation: true, // skip cosign's privacy confirmation prompt as we run non-interactively
 	}
 
 	// This command will use the provided OIDCIssuer to authenticate into Fulcio, which will generate the


### PR DESCRIPTION
Fixes #1141 #1142 

Cosign added a privacy confirmation prompt before uploading to the tlog, which causes scorecard action to fail as we dont run interactively. 

This PR adds the equivalent of the following cosign CLI option:
```
  -y, --yes   skip confirmation prompts for non-destructive operations
  ```
  
  Related: https://github.com/ossf/scorecard/pull/2918  