### PR TITLE
:book: Document the GitHub action workflow restrictions when publishing results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ________
 [Manual Action Setup](#manual-action-setup)
 - [Inputs](#inputs)
 - [Publishing Results](#publishing-results)
+- [Workflow Restrictions](#workflow-restrictions)
 - [Uploading Artifacts](#uploading-artifacts)
 - [Workflow Example](#workflow-example)
 ________
@@ -108,29 +109,6 @@ Create a Personal Access Token (PAT) for authentication and save the token value
 
 4. (Optional) If you install Scorecard on a repository owned by an organization that uses [SAML SSO](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/about-authentication-with-saml-single-sign-on), be sure to [enable SSO](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) for your PAT token.
 
-### Workflow Restrictions
-
-If [publishing results](#publishing-results), Scorecard Action sends results to our API. Our API fetches the workflow used to send the scores and [enforces certain rules](https://github.com/ossf/scorecard-webapp/blob/9c2f66d5f6ff56ca4a4ac2fba6ec8dcc5379d31c/app/server/post_results.go#L184-L187), which may reject the results and cause the Scorecard Action run to fail. 
-We understand that this is restrictive, but currently it's necessary to ensure the integrity of our API dataset, since GitHub workflow steps run in the same environment as the job they belong to.
-If possible, we will work on making this feature more flexible so we can drop this requirement in the future.
-
-#### Global workflow restrictions
-
-* The workflow can't contain top level env vars or defaults.
-* No workflow level write permissions.
-* Only the job with `ossf/scorecard-action` can use `id-token: write` permissions.
-
-#### Restrictions on the job containing `ossf/scorecard-action`
-* No job level env vars or defaults.
-* No containers or services
-* The job should run on one of the [Ubuntu hosted runners](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners)
-* The steps running in this job must belong to this approved list of GitHub actions.
-  * "actions/checkout"
-  * "actions/upload-artifact"
-  * "github/codeql-action/upload-sarif"
-  * "ossf/scorecard-action"
-  * "step-security/harden-runner"
-
 ## View Results
 
 The workflow is preconfigured to run on every repository contribution. After making a code change, you can view the results for the change either through the Scorecard Badge, Code Scanning Alerts or GitHub Workflow Runs.
@@ -193,6 +171,29 @@ available](https://github.com/ossf/scorecard#public-data).
 Setting `publish_results: true` replaces the results of the team's weekly scans with your own scan results,
 helping us scale by cutting down on repeated workflows and GitHub API requests.
 This option is also needed to enable badges on the repository.
+
+### Workflow Restrictions
+
+If [publishing results](#publishing-results), our API [enforces certain rules](https://github.com/ossf/scorecard-webapp/blob/9c2f66d5f6ff56ca4a4ac2fba6ec8dcc5379d31c/app/server/post_results.go#L184-L187) on the producing workflow, which may reject the results and cause the Scorecard Action run to fail. 
+We understand that this is restrictive, but currently it's necessary to ensure the integrity of our API dataset, since GitHub workflow steps run in the same environment as the job they belong to.
+If possible, we will work on making this feature more flexible so we can drop this requirement in the future.
+
+#### Global workflow restrictions
+
+* The workflow can't contain top level env vars or defaults.
+* No workflow level write permissions.
+* Only the job with `ossf/scorecard-action` can use `id-token: write` permissions.
+
+#### Restrictions on the job containing `ossf/scorecard-action`
+* No job level env vars or defaults.
+* No containers or services
+* The job should run on one of the [Ubuntu hosted runners](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners)
+* The steps running in this job must belong to this approved list of GitHub actions.
+  * "actions/checkout"
+  * "actions/upload-artifact"
+  * "github/codeql-action/upload-sarif"
+  * "ossf/scorecard-action"
+  * "step-security/harden-runner"
 
 ### Uploading Artifacts
 The Scorecards Action uses the [artifact uploader action](https://github.com/actions/upload-artifact) to upload results in SARIF format to the Actions tab. These results are available to anybody for five days after the run to help with debugging. To disable the upload, comment out the `Upload Artifact` value in the Workflow Example.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Note: if you disable this option, the results of the Scorecards Action run will 
 ### Workflow Example
 
 ```yml
-name: Scorecards supply-chain security
+name: Scorecard analysis workflow
 on:
   # Only the default branch is supported.
   branch_protection_rule:
@@ -202,24 +202,22 @@ permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecards analysis
+    name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
+      # Needed if using Code scanning alerts
       security-events: write
-      # Used to receive a badge. (Upcoming feature)
+      # Needed for GitHub OIDC token if publish_results is true
       id-token: write
-      actions: read
-      contents: read
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # tag=v1.1.1
+        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -238,15 +236,15 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # tag=v1.0.26
+      # required for Code scanning alerts
+      - name: "Upload SARIF results to code scanning"
+        uses: github/codeql-action/upload-sarif@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
         with:
           sarif_file: results.sarif
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Create a Personal Access Token (PAT) for authentication and save the token value
 
 ### Workflow Restrictions
 
-If [publishing results](#publishing-results), Scorecard Action sends results to our API. Our API may reject results from certain workflows, which ultimately causes the job to fail. 
+If [publishing results](#publishing-results), Scorecard Action sends results to our API. Our API fetches the workflow used to send the scores and [enforces certain rules](https://github.com/ossf/scorecard-webapp/blob/9c2f66d5f6ff56ca4a4ac2fba6ec8dcc5379d31c/app/server/post_results.go#L184-L187), which may reject the results and cause the Scorecard Action run to fail. 
 We understand that this is restrictive, but currently it's necessary to ensure the integrity of our API dataset, since GitHub workflow steps run in the same environment as the job they belong to.
 If possible, we will work on making this feature more flexible so we can drop this requirement in the future.
 


### PR DESCRIPTION
First step towards addressing #1150

I also updated some versions in the example workflow.