### PR TITLE
:seedling: Retry external network calls when publishing results

### DIFF
--- a/signing/signing.go
+++ b/signing/signing.go
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Package signing provides functionality to sign and upload results to the Scorecard API.
 package signing
 
 import (


### PR DESCRIPTION
Recreation of #1037 with a variable backoff. This backoff is used for both interactions with Sigstore, and interactions with our own webapp.

These issues are cropping up more frequently:
Fixes #1190
Fixes #1189
Fixes #1188
Fixes #1186
Fixes #1179
Fixes #1177
Fixes #1163
Fixes #1157
Fixes #1148
Fixes #1132