### PR TITLE
:seedling: Bump docker tag for v2.2.0 release.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.1.3"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.2.0"


### PR DESCRIPTION
Notable changes (will be more detailed in release notes)
* Scorecard bump to v4.11.0
* Scorecard Result Viewer, highlighting the badge linking instructions
* Publishing result QoL changes
  * Runs that fail our workflow restrictions will fail with a 400 response indicating the problem, instead of a vague 500 status. 
  * Scorecard action will retry when signing results and submitting them to our web API. This should help with flakiness from connection failures
* doc changes
  * fine-grained tokens instructions
  * updated action installation instructions