### PR TITLE
Prevent url clipping for GHES instances

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -84,11 +84,7 @@ func (c *Client) ParseFromURL(baseRepoURL, repoName string) (RepoInfo, error) {
 	if err != nil {
 		return ret, fmt.Errorf("parsing base repo URL: %w", err)
 	}
-
-	repoURL, err := baseURL.Parse(fmt.Sprintf("repos/%s", repoName))
-	if err != nil {
-		return ret, fmt.Errorf("parsing repo endpoint: %w", err)
-	}
+	repoURL := baseURL.JoinPath(fmt.Sprintf("repos/%s", repoName))
 
 	log.Printf("getting repo info from URL: %s", repoURL.String())
 	//nolint:noctx


### PR DESCRIPTION
We want to run this action against our internal GHES instance which is now supported with the release of [scorecard v4.11.0](https://github.com/ossf/scorecard/releases/tag/v4.11.0). 

The call I changed makes the path to the API call additive, where as baseURL.Parse removed the last part of the url. For example, with the Parse method `https://github.corp.com/api/v3` became `https://github.corp.com/api/repos/<reponame>` which ofc does not resolve.

With this change the URL is correct.  


> Note: 
This is the first step in getting support for running this against your own GHES instance. The next is authenticating the calls to the repos end point, but I want to create a separate PR for that (I have a crude version working against our internal server). That should also remediate a lot of [this issue](https://github.com/ossf/scorecard-action/blob/33bb591983cdd3feffdbe87b9719c784f7e90ac1/entrypoint/entrypoint.go#L82), although not 100%.