### PR TITLE
Authenticate get repo call if authentication info available

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -101,6 +101,13 @@ func (c *Client) ParseFromURL(baseRepoURL, repoName string) (RepoInfo, error) {
 		return ret, fmt.Errorf("error creating request: %w", err)
 	}
 
+	// authenticate the request if there is a token
+	// this will lower the change of hitting the rate limit
+	auth, present := os.LookupEnv("GITHUB_AUTH_TOKEN")
+	if present {
+		req.SetBasicAuth("x", auth)
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return ret, fmt.Errorf("error creating request: %w", err)


### PR DESCRIPTION
Building the missing authentication for private repos and running against EMU / GHES environments. Setup is straightforward: if there is an authentication token available (which is used inside of `scorecard`, then we can authenticate the call to get the repository information here as well. 