### PR TITLE
Add SECURITY.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,8 @@ an external contributor could potentially exploit it to extract the PAT.
 
 The only benefit of a "classic" PAT is that it can be set to never expire.
 However, we believe this does not outweigh the significantly higher risk of "classic" PATs compared to fine-grained PATs.
+
+## Reporting vulnerabilities
+
+If you find a vulnerability, please report it to us!
+See [SECURITY.md](./SECURITY.md) for more information.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ________
 - [Workflow Example](#workflow-example)
 
 ["Classic" PAT Requirements and Risks](#classic-personal-access-token-pat-requirements-and-risks)
+
+[Reporting vulnerabilities](#reporting-vulnerabilities)
 ________
 
 The following GitHub triggers are supported: `push`, `schedule` (default branch only).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security
+
+If you find a significant vulnerability, or evidence of one,
+please report it privately.
+
+We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
+[main repository's security tab](https://github.com/coreinfrastructure/best-practices-badge/security), in the left sidebar, under "Reporting", click
+Advisories, then click "Report a vulnerability" to open the advisory form.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,5 +4,4 @@ If you find a significant vulnerability, or evidence of one,
 please report it privately.
 
 We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
-main repository's security tab, under "Reporting", click
-Advisories, then click "Report a vulnerability" to open the advisory form.
+[main repository's security tab](https://github.com/ossf/scorecard-action/security), click "Report a vulnerability" to open the advisory form.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,5 +4,5 @@ If you find a significant vulnerability, or evidence of one,
 please report it privately.
 
 We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
-[main repository's security tab](https://github.com/coreinfrastructure/best-practices-badge/security), in the left sidebar, under "Reporting", click
+main repository's security tab, under "Reporting", click
 Advisories, then click "Report a vulnerability" to open the advisory form.


### PR DESCRIPTION
This commit adds a SECURITY.md file, so panicked reporters will know how to report them. Since private reporting is enabled, I presume that's how this group wants the vulnerabilities reported.

I also tweaked the README to point to it.