### PR TITLE
Fix typo in token input docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We therefore suggest you create a fine-grained Personal Access Token (PAT) that 
 
     Note that fine-grained tokens expire after one year. You'll receive an email from GitHub when your token is about to expire, at which point you must regenerate it. Make sure to update the token string in your repository's secrets.
 
-4. When you call the `ossf/scorecard-action` in your workflow, pass the token as `repo-token: ${{ secrets.SCORECARD_TOKEN }}`.
+4. When you call the `ossf/scorecard-action` in your workflow, pass the token as `repo_token: ${{ secrets.SCORECARD_TOKEN }}`.
 
 ## View Results
 


### PR DESCRIPTION
It's trivial but annoying because the workflow doesn't fail when using `repo-token` but shows a warning in the annotation section.

```
Unexpected input(s) 'repo-token', valid inputs are ['entryPoint', 'args', 'results_file', 'results_format', 'repo_token', 'publish_results', 'internal_publish_base_url', 'internal_default_token']
```