### PR TITLE
:seedling: Upgrade to go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@
 #           -e GITHUB_REPOSITORY="ossf/scorecard" \
 #           laurentsimon/scorecard-action:latest
 
-#v1.19 go
 FROM golang:1.21.1@sha256:cffaba795c36f07e372c7191b35ceaae114d74c31c3763d442982e3a4df3b39e AS builder
 WORKDIR /src
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/scorecard-action
 
-go 1.19
+go 1.20
 
 require (
 	github.com/caarlos0/env/v6 v6.10.1


### PR DESCRIPTION
One of our dependencies specifies 1.20 in its `go.mod`, so the upgrade is failing. (#1254). At some point we'll probably need to bump again to 1.21. 

Note: our Dockerfile already uses 1.21, but ultimately the runtime behavior is based on whats in our go.mod