### PR TITLE
:seedling: Bump docker tag to for v2.3.0 release.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.2.0"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.3.0"


### PR DESCRIPTION
Notable changes (will be more detailed in release notes)
* Scorecard bump to v4.13.0
  * Which includes some scoring changes and repo rules support
* Small change in what we send to the webapp when publishing results
* documentation changes

I ran the nightly e2e tests after upgrading to scorecard v4.13.0 and they all passed:
https://github.com/ossf-tests/scorecard-action/actions/runs/6434998535