### PR TITLE
:seedling: Group Dependabot updates for GitHub Actions and Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "docker"
     directory: /
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: ":seedling:"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,18 @@ updates:
       github-actions:
         patterns:
           - "*"
-      
+
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"
     directory: /
-    open-pull-requests-limit: 20
     schedule:
       interval: "daily"
     commit-message:
       prefix: ":seedling:"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
 
   # Maintain dependencies for go
   - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,14 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    open-pull-requests-limit: 20
     schedule:
       interval: "weekly"
     commit-message:
       prefix: ":seedling:"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
       
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
The majority of our dependency updates are GitHub Action updates, and Dockerfile updates. The Go updates have a more direct effect on the code and are more spread out, so I didn't group them.

https://github.com/ossf/scorecard-action/pulls?q=is%3Apr+label%3Adependencies+is%3Aclosed