### PR TITLE
:book: link to `ossf/scorecard` workflow instead of maintaining an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,67 +166,8 @@ Note: if you disable this option, the results of the Scorecards Action run will 
 
 ### Workflow Example
 
-```yml
-name: Scorecard analysis workflow
-on:
-  # Only the default branch is supported.
-  branch_protection_rule:
-  schedule:
-    # Weekly on Saturdays.
-    - cron: '30 1 * * 6'
-  push:
-    branches: [ main, master ]
-
-# Declare default permissions as read only.
-permissions: read-all
-
-jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed if using Code scanning alerts
-      security-events: write
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
-
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          persist-credentials: false
-
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # (Optional) fine-grained personal access token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
-          # Publish the results for public repositories to enable scorecard badges. For more details, see
-          # https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories, `publish_results` will automatically be set to `false`, regardless
-          # of the value entered here.
-          publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # required for Code scanning alerts
-      - name: "Upload SARIF results to code scanning"
-        uses: github/codeql-action/upload-sarif@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
-        with:
-          sarif_file: results.sarif
-```
+Please see our workflow from `ossf/scorecard` for an up-to-date example.
+https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml
 
 ## Reporting vulnerabilities
 


### PR DESCRIPTION
This way dependabot will keep the workflow updated for us, and we don't need to remember to update anything here.

Fixes https://github.com/ossf/scorecard/issues/3968