### PR TITLE
:seedling: specify `golangci-lint` version in action

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -23,4 +23,5 @@ jobs:
           cache: false # golangci/golangci-lint-action maintains its own cache
       - uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
+          version: v1.55.2
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 ---
 run:
   concurrency: 6
-  deadline: 5m
+  timeout: 5m
 issues:
   include:
     # revive `package-comments` and `exported` rules.


### PR DESCRIPTION
If we don't set it, the action uses the latest release, which changes outside our control.
Version changes should be controlled, as new linter versions often lead to new findings which need to be dealt with.

Also use `timeout` instead of `deadline` in our configuration.
`deadline` was deprecated in 2019 and support was removed in v1.57.0 of golangci-lint