### PR TITLE
:seedling: Bump github.com/ossf/scorecard/v5 from v5.0.0-rc2 to v5.0.0-rc2.0.20240509182734-7ce860946928

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # NOTE: Keep this in sync with go.mod for ossf/scorecard.
-LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.0.0-rc2 -X sigs.k8s.io/release-utils/version.gitCommit=6b5cb27cd011f6f3657e703b28ea824b9eae7552 -w -extldflags \"-static\"
+LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.0.0-rc2 -X sigs.k8s.io/release-utils/version.gitCommit=7ce8609469289d5f3b1bf5ee3122f42b4e3054fb -w -extldflags \"-static\"
 
 build: ## Runs go build on repo
 	# Run go build and generate scorecard executable

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v46 v46.0.0
-	github.com/ossf/scorecard/v5 v5.0.0-rc2
+	github.com/ossf/scorecard/v5 v5.0.0-rc2.0.20240509182734-7ce860946928
 	github.com/sigstore/cosign/v2 v2.2.4
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/net v0.25.0
@@ -34,7 +34,6 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/CycloneDX/cyclonedx-go v0.8.0 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/CycloneDX/cyclonedx-go v0.8.0 h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M=
 github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -600,8 +598,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/ossf/scorecard/v5 v5.0.0-rc2 h1:1DIWhvJHIQCewGx3V+7Rjq/HIseF/rAe8aTNEEsug6g=
-github.com/ossf/scorecard/v5 v5.0.0-rc2/go.mod h1:+Q01OdiS66+bbEyRf6DchrIK+YWpzqcfX2XG5Nbyvyg=
+github.com/ossf/scorecard/v5 v5.0.0-rc2.0.20240509182734-7ce860946928 h1:kZDV/onu2grzSHKSlwclW0p6iDCipgYgxk3otkGocNk=
+github.com/ossf/scorecard/v5 v5.0.0-rc2.0.20240509182734-7ce860946928/go.mod h1:PLkYxsNpLeixKC9I95+EfIbkP/91RFfjEmMyG8pzayc=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.1 h1:77opmuqxQZE1UF6TylFz5XllVEI72WijgwpwNw4JTmY=
 github.com/owenrumney/go-sarif/v2 v2.3.1/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=


### PR DESCRIPTION
Includes the ossf/scorecard#4097 bug fix before cutting v2.3.2