### PR TITLE
bump docker tag to v2.4.0 for release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,4 +53,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.3.3"
+  image: "docker://gcr.io/openssf/scorecard-action:v2.4.0"


### PR DESCRIPTION
The main change is the Scorecard bump to v5.0.0, which includes maintainer annotations which will affect the SARIF produced by this action.

For full details see the release notes:
https://github.com/ossf/scorecard/releases/tag/v5.0.0