### PR TITLE
fix result file path issues

### DIFF
--- a/internal/scorecard/format.go
+++ b/internal/scorecard/format.go
@@ -45,7 +45,7 @@ func Format(result *scorecard.Result, opts *options.Options) error {
 	}
 
 	// write results to both stdout and result file
-	resultFile, err := os.Create(opts.GithubWorkspace + opts.InputResultsFile)
+	resultFile, err := os.Create(opts.GithubWorkspace + "/" + opts.InputResultsFile)
 	if err != nil {
 		return fmt.Errorf("creating result file: %w", err)
 	}

--- a/internal/scorecard/format.go
+++ b/internal/scorecard/format.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/ossf/scorecard-action/options"
@@ -45,7 +46,7 @@ func Format(result *scorecard.Result, opts *options.Options) error {
 	}
 
 	// write results to both stdout and result file
-	resultFile, err := os.Create(opts.GithubWorkspace + "/" + opts.InputResultsFile)
+	resultFile, err := os.Create(filepath.Join(opts.GithubWorkspace, opts.InputResultsFile))
 	if err != nil {
 		return fmt.Errorf("creating result file: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/ossf/scorecard-action/internal/scorecard"
 	"github.com/ossf/scorecard-action/options"
@@ -61,7 +62,7 @@ func main() {
 			}
 		}
 
-		resultFile := opts.GithubWorkspace + "/" + opts.InputResultsFile
+		resultFile := filepath.Join(opts.GithubWorkspace, opts.InputResultsFile)
 		jsonPayload, err := os.ReadFile(resultFile)
 		if err != nil {
 			log.Fatalf("reading json scorecard results: %v", err)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,8 @@ func main() {
 			}
 		}
 
-		jsonPayload, err := os.ReadFile(opts.InputResultsFile)
+		resultFile := opts.GithubWorkspace + "/" + opts.InputResultsFile
+		jsonPayload, err := os.ReadFile(resultFile)
 		if err != nil {
 			log.Fatalf("reading json scorecard results: %v", err)
 		}
@@ -74,7 +75,7 @@ func main() {
 			log.Fatalf("error SigningNew: %v", err)
 		}
 		// TODO: does it matter if this is hardcoded as results.json or not?
-		if err = s.SignScorecardResult(opts.InputResultsFile); err != nil {
+		if err = s.SignScorecardResult(resultFile); err != nil {
 			log.Fatalf("error signing scorecard json results: %v", err)
 		}
 


### PR DESCRIPTION
There were two issues at play that prevented the binary from reading the correct results file:

1. The paths were not joined with a separator during the refactor in #1423. This led to file not found errors, as the file was saved in the wrong directory, with the wrong name.
2. The signing code tried to read the file from the working directory instead of the GitHub workspace directory.

I was able to test this code after modifying the testing command in the `Dockerfile` to use a different `GITHUB_WORKSPACE` directory. The signing portion of the code will need to wait until the e2e test to confirm the fix.

We should eventually improve the [testing instructions](https://github.com/ossf/scorecard-action/blob/ab9729375aeb5f298cbbdcf9167c9fd974416537/Dockerfile#L15-L23), but at least the e2e test we have now caught this (via #1426 and #1427):
```shell
docker run -e GITHUB_REF=refs/heads/main \
     -e GITHUB_EVENT_NAME=branch_protection_rule \
    -e INPUT_RESULTS_FORMAT=json \
    -e INPUT_RESULTS_FILE=results.json \
    -e GITHUB_WORKSPACE="/home/runner/work/spencerschrock/actions-test" \
    -e INPUT_POLICY_FILE="/policy.yml" \
    -e INPUT_REPO_TOKEN=$GITHUB_AUTH_TOKEN \
    -e GITHUB_REPOSITORY="spencerschrock/actions-test" \
    -e GITHUB_EVENT_PATH="/event.json" \
    -e GITHUB_API_URL="https://api.github.com" \
    -e INPUT_PUBLISH_RESULTS="true" \
    -v /tmp/docker:/home/runner/work/spencerschrock/actions-test \
    spencerschrock/scorecard-action:latest
```

Fixes #1426
Fixes #1427
Fixes #1429