### PR TITLE
:seedling: bump docker to ghcr v2.4.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,7 +57,7 @@ Example:
 ```
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:Tag"
+  image: "docker://ghcr.io/ossf/scorecard-action:Tag"
 ```
 
 Create a pull request with this change and merge into `main`.

--- a/action.yaml
+++ b/action.yaml
@@ -58,4 +58,4 @@ branding:
 
 runs:
   using: "docker"
-  image: "docker://gcr.io/openssf/scorecard-action:v2.4.0"
+  image: "docker://ghcr.io/ossf/scorecard-action:v2.4.1"


### PR DESCRIPTION
This includes both the version bump, and uses the new GHCR image.

Initially sent as a draft PR, as there are a few steps left in the process:
- [x] scorecard upgrade?
- [x] release notes
- [x] promote webapp staging to prod
- [ ] ?

Fixes #1473 
Fixes #1499
