### PR TITLE
add input for specifying `--file-mode`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # NOTE: Keep this in sync with go.mod for ossf/scorecard.
-LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.1.0 -X sigs.k8s.io/release-utils/version.gitCommit=b0143fc57d8d38748990027266de715052806f4b -w -extldflags \"-static\"
+LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.1.1 -X sigs.k8s.io/release-utils/version.gitCommit=cd152cb6742c5b8f2f3d2b5193b41d9c50905198 -w -extldflags \"-static\"
 
 build: ## Runs go build on repo
 	# Run go build and generate scorecard executable

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ First, [create a new file](https://docs.github.com/en/repositories/working-with-
 
 | Name | Required | Description |
 | ----- | -------- | ----------- |
-| `result_file` | yes | The file that contains the results. |
-| `result_format` | yes | The format in which to store the results [json \| sarif]. For GitHub's scanning dashboard, select `sarif`. |
+| `results_file` | yes | The file that contains the results. |
+| `results_format` | yes | The format in which to store the results [json \| sarif]. For GitHub's scanning dashboard, select `sarif`. |
 | `repo_token` | no | PAT token with repository read access. Follow [these steps](/docs/authentication/fine-grained-auth-token.md) to create it. |
 | `publish_results` | recommended | This will allow you to display a badge on your repository to show off your hard work. See details [here](#publishing-results).|
+| `file_mode` | no | The method to fetch files from the repository: `archive` or `git` (default `archive`).
 
 ### Publishing Results
 The Scorecard team runs a weekly scan of public GitHub repositories in order to track

--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,11 @@ inputs:
     required: false
     default: false
 
+  file_mode:
+    description: "INPUT: Method to fetch files from GitHub"
+    required: false
+    default: archive
+
   internal_publish_base_url:
     description: "INPUT: Base URL for publishing results. Used for testing."
     required: false

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v46 v46.0.0
-	github.com/ossf/scorecard/v5 v5.1.0
+	github.com/ossf/scorecard/v5 v5.1.1
 	github.com/sigstore/cosign/v2 v2.4.2
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/net v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/ossf/scorecard/v5 v5.1.0 h1:onGMdLkflcsc2OOLiqpdY1Y4RGWicK3V9/q6qGWLqP4=
-github.com/ossf/scorecard/v5 v5.1.0/go.mod h1:LPrCMUyDZyEbJXgRDLWP6IKl9rPDooYY15T2FYMJxYY=
+github.com/ossf/scorecard/v5 v5.1.1 h1:PbEs+JznKjwXyk9N1voOOwFqVNuFKfr0URNt9TBjLeo=
+github.com/ossf/scorecard/v5 v5.1.1/go.mod h1:LPrCMUyDZyEbJXgRDLWP6IKl9rPDooYY15T2FYMJxYY=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=
 github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=

--- a/internal/scorecard/scorecard.go
+++ b/internal/scorecard/scorecard.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ossf/scorecard-action/options"
 	"github.com/ossf/scorecard/v5/clients"
@@ -35,7 +36,11 @@ func Run(opts *options.Options) (scorecard.Result, error) {
 		return scorecard.Result{}, fmt.Errorf("unable to create repo: %w", err)
 	}
 
-	result, err := scorecard.Run(context.Background(), repo)
+	var scOpts []scorecard.Option
+	if strings.EqualFold(opts.InputFileMode, "git") {
+		scOpts = append(scOpts, scorecard.WithFileModeGit())
+	}
+	result, err := scorecard.Run(context.Background(), repo, scOpts...)
 	if err != nil && !errors.Is(err, sce.ErrCheckRuntime) {
 		return scorecard.Result{}, fmt.Errorf("scorecard had an error: %w", err)
 	}

--- a/options/env.go
+++ b/options/env.go
@@ -43,6 +43,7 @@ const (
 	EnvInputResultsFile            = "INPUT_RESULTS_FILE"
 	EnvInputResultsFormat          = "INPUT_RESULTS_FORMAT"
 	EnvInputPublishResults         = "INPUT_PUBLISH_RESULTS"
+	EnvInputFileMode               = "INPUT_FILE_MODE"
 	EnvInputInternalPublishBaseURL = "INPUT_INTERNAL_PUBLISH_BASE_URL"
 )
 

--- a/options/options.go
+++ b/options/options.go
@@ -77,6 +77,7 @@ type Options struct {
 	// Input parameters
 	InputResultsFile   string `env:"INPUT_RESULTS_FILE"`
 	InputResultsFormat string `env:"INPUT_RESULTS_FORMAT"`
+	InputFileMode      string `env:"INPUT_FILE_MODE"`
 
 	PublishResults bool
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -48,6 +48,7 @@ func TestNew(t *testing.T) {
 		Local       string
 		ChecksToRun []string
 		ShowDetails bool
+		FileMode    string
 	}
 	tests := []struct {
 		name             string
@@ -58,6 +59,7 @@ func TestNew(t *testing.T) {
 		resultsFile      string
 		resultsFormat    string
 		publishResults   string
+		fileMode         string
 		want             fields
 		unsetResultsPath bool
 		unsetToken       bool
@@ -71,6 +73,7 @@ func TestNew(t *testing.T) {
 			repo:            testRepo,
 			resultsFormat:   "sarif",
 			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      formatSarif,
@@ -80,6 +83,7 @@ func TestNew(t *testing.T) {
 				LogLevel:    options.DefaultLogLevel,
 				Repo:        testRepo,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			wantErr: false,
 		},
@@ -91,6 +95,7 @@ func TestNew(t *testing.T) {
 			repo:            testRepo,
 			resultsFormat:   "json",
 			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      options.FormatJSON,
@@ -99,6 +104,29 @@ func TestNew(t *testing.T) {
 				LogLevel:    options.DefaultLogLevel,
 				Repo:        testRepo,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
+			},
+			wantErr: false,
+		},
+		{
+			name:            "SuccessFileModeGit",
+			githubEventPath: githubEventPathNonFork,
+			githubEventName: pushEvent,
+			githubRef:       "refs/heads/main",
+			repo:            testRepo,
+			resultsFormat:   "sarif",
+			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeGit,
+			want: fields{
+				EnableSarif: true,
+				Format:      formatSarif,
+				PolicyFile:  defaultScorecardPolicyFile,
+				ResultsFile: testResultsFile,
+				Commit:      options.DefaultCommit,
+				LogLevel:    options.DefaultLogLevel,
+				Repo:        testRepo,
+				ShowDetails: true,
+				FileMode:    options.FileModeGit,
 			},
 			wantErr: false,
 		},
@@ -110,6 +138,7 @@ func TestNew(t *testing.T) {
 			repo:            testRepo,
 			resultsFormat:   "json",
 			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      options.FormatJSON,
@@ -118,6 +147,7 @@ func TestNew(t *testing.T) {
 				LogLevel:    options.DefaultLogLevel,
 				Local:       ".",
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			wantErr: false,
 		},
@@ -129,6 +159,7 @@ func TestNew(t *testing.T) {
 			repo:            testRepo,
 			resultsFormat:   "json",
 			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      options.FormatJSON,
@@ -137,6 +168,7 @@ func TestNew(t *testing.T) {
 				LogLevel:    options.DefaultLogLevel,
 				Repo:        testRepo,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			wantErr: false,
 		},
@@ -148,6 +180,7 @@ func TestNew(t *testing.T) {
 			repo:            testRepo,
 			resultsFormat:   "sarif",
 			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      formatSarif,
@@ -157,6 +190,7 @@ func TestNew(t *testing.T) {
 				LogLevel:    options.DefaultLogLevel,
 				Repo:        testRepo,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			unsetToken: true,
 			wantErr:    true,
@@ -166,6 +200,7 @@ func TestNew(t *testing.T) {
 			githubEventPath: githubEventPathNonFork,
 			githubEventName: pushEvent,
 			githubRef:       "refs/heads/main",
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      formatSarif,
@@ -173,6 +208,7 @@ func TestNew(t *testing.T) {
 				Commit:      options.DefaultCommit,
 				LogLevel:    options.DefaultLogLevel,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			unsetResultsPath: true,
 			wantErr:          true,
@@ -183,6 +219,7 @@ func TestNew(t *testing.T) {
 			githubEventName: pushEvent,
 			githubRef:       "refs/heads/main",
 			resultsFile:     "",
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      formatSarif,
@@ -191,6 +228,7 @@ func TestNew(t *testing.T) {
 				Commit:      options.DefaultCommit,
 				LogLevel:    options.DefaultLogLevel,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			wantErr: true,
 		},
@@ -202,6 +240,7 @@ func TestNew(t *testing.T) {
 			repo:            testRepo,
 			resultsFormat:   "sarif",
 			resultsFile:     testResultsFile,
+			fileMode:        options.FileModeArchive,
 			want: fields{
 				EnableSarif: true,
 				Format:      formatSarif,
@@ -211,6 +250,7 @@ func TestNew(t *testing.T) {
 				LogLevel:    options.DefaultLogLevel,
 				Repo:        testRepo,
 				ShowDetails: true,
+				FileMode:    options.FileModeArchive,
 			},
 			wantErr: true,
 		},
@@ -243,6 +283,8 @@ func TestNew(t *testing.T) {
 			os.Setenv(EnvInputResultsFormat, tt.resultsFormat)
 			defer os.Unsetenv(EnvInputResultsFormat)
 
+			t.Setenv(EnvInputFileMode, tt.fileMode)
+
 			if tt.unsetResultsPath {
 				os.Unsetenv(EnvInputResultsFile)
 			} else {
@@ -263,6 +305,7 @@ func TestNew(t *testing.T) {
 				Local:       scOpts.Local,
 				ChecksToRun: scOpts.ChecksToRun,
 				ShowDetails: scOpts.ShowDetails,
+				FileMode:    opts.InputFileMode,
 			}
 
 			if err != nil {


### PR DESCRIPTION
Introduced upstream in https://github.com/ossf/scorecard/pull/4474

Also updates Scorecard to v5.1.1 for the data race fix.