### PR TITLE
omit vcs info from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.1.1 -X sigs.k8s.io/re
 
 build: ## Runs go build on repo
 	# Run go build and generate scorecard executable
-	CGO_ENABLED=0 go build -o scorecard-action -trimpath -a -tags netgo -ldflags '$(LDFLAGS)'
+	CGO_ENABLED=0 go build -o scorecard-action -trimpath -a -tags netgo -buildvcs=false -ldflags '$(LDFLAGS)'


### PR DESCRIPTION
The detected info is interfering with the manually specified Scorecard version in the LDFLAGS. While `buildvcs` has been present since Go 1.18, Go 1.24 changed the behavior again. Our docker image uses Go 1.24 as of 3676bbc29082184ac34a84d1573c0419f81c4a68.

https://go.dev/doc/go1.24#go-command

> The go build command now sets the [main module’s version](https://go.dev/pkg/runtime/debug#BuildInfo.Main) in the compiled binary based on the version control system tag and/or commit. A +dirty suffix will be appended if there are uncommitted changes. Use the -buildvcs=false flag to omit version control information from the binary.

This trickled down to the produced output:
Before this PR:
```json
"scorecard": { 
  "version":"v0.0.0-20250218152336-6a62a1cbf280",
  "commit":"cd152cb6742c5b8f2f3d2b5193b41d9c50905198"
}
```
After:
```json
"scorecard": {
  "version":"v5.1.1",
  "commit":"cd152cb6742c5b8f2f3d2b5193b41d9c50905198"
}
```