### PR TITLE
:seedling: Bump github.com/ossf/scorecard/v5 from v5.2.0 to v5.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # NOTE: Keep this in sync with go.mod for ossf/scorecard.
-LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.2.0 -X sigs.k8s.io/release-utils/version.gitCommit=f08e8fbdb73dbde0533803fdbad3fd4186825314 -w -extldflags \"-static\"
+LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=v5.2.1 -X sigs.k8s.io/release-utils/version.gitCommit=ab2f6e92482462fe66246d9e32f642855a691dc1 -w -extldflags \"-static\"
 
 build: ## Runs go build on repo
 	# Run go build and generate scorecard executable

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v46 v46.0.0
-	github.com/ossf/scorecard/v5 v5.2.0
+	github.com/ossf/scorecard/v5 v5.2.1
 	github.com/sigstore/cosign/v2 v2.5.0
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/net v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -652,8 +652,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/ossf/scorecard/v5 v5.2.0 h1:OOrrqnw9AIRq4m/P7h4FmMfYUVM57iEPIS74mrfM6so=
-github.com/ossf/scorecard/v5 v5.2.0/go.mod h1:MtWFtmWDaVZkbRrXdjGb6zYQf5LcTI1aGC9Chmx6hIM=
+github.com/ossf/scorecard/v5 v5.2.1 h1:p88yEhbyn8ReVWbQRstOaw+8sG/Qte78CAGoPqJZD3k=
+github.com/ossf/scorecard/v5 v5.2.1/go.mod h1:MtWFtmWDaVZkbRrXdjGb6zYQf5LcTI1aGC9Chmx6hIM=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=
 github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=


### PR DESCRIPTION
https://github.com/ossf/scorecard/releases/tag/v5.2.1