### PR TITLE
add missing top-level token permissions to workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,13 +20,15 @@ on:
   schedule:
     - cron: '17 19 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
       security-events: write
 
     strategy:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Improve the `Token Permissions` score, see https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard-action

```
Reason
detected GitHub workflow tokens with excessive permissions
Details
Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql-analysis.yml:28
Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql-analysis.yml:29
Warn: jobLevel 'packages' permission set to 'write': .github/workflows/ghcr-retention.yml:13
Warn: no topLevel permission defined: .github/workflows/codeql-analysis.yml:1
Info: topLevel 'contents' permission set to 'read': .github/workflows/dependency-review.yml:27
Warn: no topLevel permission defined: .github/workflows/docker-image.yml:1
Info: found token with 'none' permissions: .github/workflows/ghcr-retention.yml:1
Info: topLevel 'contents' permission set to 'read': .github/workflows/ghcr.yml:13
Info: topLevel 'contents' permission set to 'read': .github/workflows/golangci.yml:9
Info: topLevel permissions set to 'read-all': .github/workflows/scorecards.yml:6
Info: topLevel permissions set to 'read-all': .github/workflows/tests.yaml:8
```