### PR TITLE
:book: Add missing ENV to development docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,7 @@ docker run -e INPUT_REPO_TOKEN="$GITHUB_AUTH_TOKEN" \
            -e GITHUB_EVENT_NAME="branch_protection_rule" \
            -e GITHUB_EVENT_PATH="/testdata/fork.json" \
            -e GITHUB_REPOSITORY="ossf/scorecard" \
+           -e GITHUB_API_URL="https://api.github.com" \
            scorecard-action:testing
 ```
 


### PR DESCRIPTION
Without setting this env, I get the following:

```
$ docker run -e INPUT_REPO_TOKEN="$GITHUB_AUTH_TOKEN" -e INPUT_POLICY_FILE="/policy.yml" -e INPUT_RESULTS_FORMAT="sarif" -e INPUT_RESULTS_FILE="results.sarif" -e INPUT_PUBLISH_RESULTS="false" -e GITHUB_WORKSPACE="/" -e GITHUB_REF="refs/heads/main" -e GITHUB_EVENT_NAME="branch_protection_rule" -e GITHUB_EVENT_PATH="/testdata/fork.json" -e GITHUB_REPOSITORY="ossf/scorecard" -it scorecard-action:testing
2025/09/24 17:27:09 getting repo info from file: /testdata/fork.json
2025/09/24 17:27:09 getting repo info from URL: repos/ossf/scorecard
FromURL: error receiving response: Get "repos/ossf/scorecard": unsupported protocol scheme "".
FromRepoInfo: error receiving response: Get "repos/ossf/scorecard": unsupported protocol scheme "".
2025/09/24 17:27:09 creating new options: parsing repo info: GitHub repo info inaccessible
```

Passing the `GITHUB_API_URL` env as well seems to fix it.