### PR TITLE
:book: Fix recommended command to test the image in development

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,7 @@ docker run -e INPUT_REPO_TOKEN="$GITHUB_AUTH_TOKEN" \
            -e GITHUB_EVENT_NAME="branch_protection_rule" \
            -e GITHUB_EVENT_PATH="/testdata/fork.json" \
            -e GITHUB_REPOSITORY="ossf/scorecard" \
+           --mount type=bind,source=./options/testdata/fork.json,destination=/testdata/fork.json,readonly \
            scorecard-action:testing
 ```
 


### PR DESCRIPTION
Because no testdata files are actually copied to the image, we fail to read the event file and fallback to fetching the information from GitHub API.

Howver, that's not actually working because the `GITHUB_API_URL` environment is missing.

To fix it, we could pass the `GITHUB_API_URL`. However, I think actually making the testdata file available to the container mimics better what happens in real life.

This is an alternative to #1582.