### PR TITLE
:seedling: Improve printing options

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -140,19 +140,19 @@ func (o *Options) Validate() error {
 func (o *Options) Print() {
 	// Scorecard options
 	fmt.Println("Scorecard options:")
-	fmt.Printf("Ref: %s\n", o.ScorecardOpts.Commit)
-	fmt.Printf("Repository: %s\n", o.ScorecardOpts.Repo)
-	fmt.Printf("Local: %s\n", o.ScorecardOpts.Local)
-	fmt.Printf("Format: %s\n", o.ScorecardOpts.Format)
-	fmt.Printf("Policy file: %s\n", o.ScorecardOpts.PolicyFile)
+	fmt.Printf("  Ref: %s\n", o.ScorecardOpts.Commit)
+	fmt.Printf("  Repository: %s\n", o.ScorecardOpts.Repo)
+	fmt.Printf("  Local: %s\n", o.ScorecardOpts.Local)
+	fmt.Printf("  Format: %s\n", o.ScorecardOpts.Format)
+	fmt.Printf("  Policy file: %s\n", o.ScorecardOpts.PolicyFile)
 	fmt.Println()
 	fmt.Println("Event / repo information:")
-	fmt.Printf("Event file: %s\n", o.GithubEventPath)
-	fmt.Printf("Event name: %s\n", o.GithubEventName)
-	fmt.Printf("Fork repository: %s\n", o.IsForkStr)
-	fmt.Printf("Private repository: %s\n", o.PrivateRepoStr)
-	fmt.Printf("Publication enabled: %+v\n", o.PublishResults)
-	fmt.Printf("Default branch: %s\n", o.DefaultBranch)
+	fmt.Printf("  Event file: %s\n", o.GithubEventPath)
+	fmt.Printf("  Event name: %s\n", o.GithubEventName)
+	fmt.Printf("  Fork repository: %s\n", o.IsForkStr)
+	fmt.Printf("  Private repository: %s\n", o.PrivateRepoStr)
+	fmt.Printf("  Publication enabled: %+v\n", o.PublishResults)
+	fmt.Printf("  Default branch: %s\n", o.DefaultBranch)
 }
 
 func (o *Options) setScorecardOpts() {


### PR DESCRIPTION
When print options, there are two sections: "Scorecard options:" and "Event / repo information:". However, the headers of these sections have the same format as the options themselves (name followed by ":"). So I initially failed to identify they were just headers, and thought they were actual options that were empty.

I think indenting entries inside each section helps avoid this confusion.

Before:

```console
Scorecard options:
Ref: HEAD
Repository: ossf/scorecard
Local:
Format: sarif
Policy file: /policy.yml

Event / repo information:
Event file: /testdata/fork.json
Event name: branch_protection_rule
Fork repository: true
Private repository: true
Publication enabled: false
Default branch: main
```

After:

```console
Scorecard options:
  Ref: HEAD
  Repository: ossf/scorecard
  Local:
  Format: sarif
  Policy file: /policy.yml

Event / repo information:
  Event file: /testdata/fork.json
  Event name: branch_protection_rule
  Fork repository: true
  Private repository: true
  Publication enabled: false
  Default branch: main
```